### PR TITLE
Fix a bug where protocol-relative URL would be mis-parsed.

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,14 +46,10 @@ function extract(opts, cb) {
       } else if (name === 'img') {
         let src = attrs.src;
         if (src && src.substr(0, 4) !== 'data') {
-          if (src[0] === '/') {
-            src = host + src;
-          }
-
           if (!res.images) {
             res.images = new Set();
           }
-          res.images.add(src);
+          res.images.add(url.resolve(host, src));
         }
       }
     },

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function extract(opts, cb) {
           if (!res.images) {
             res.images = new Set();
           }
-          res.images.add(url.resolve(host, src));
+          res.images.add(url.resolve(opts.uri, src));
         }
       }
     },


### PR DESCRIPTION
Test url: https://www.youtube.com/watch?v=9M77quPL3vY&list=RDEMhe2AFH_WvB5nuMd9tU5CHg&index=27

They use protocol-relative urls (`//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif`)

 `meta-extractor` winds up producing: `https://www.youtube.com//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif`
