### PR TITLE
Only set User-Agent if not user provided

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,11 +152,13 @@ function _extract(opts, done) {
   const uri = opts.uri;
   const limit = opts.limit || 2 * 1024 * 1024;
   opts.headers = Object.assign(
-    {
-      "User-Agent": USERAGENT,
-    },
+    {},
     opts.headers
   );
+  
+  if (opts.headers["user-agent"] == undefined && opts.headers["User-Agent"] == undefined) {
+    opts.headers["User-Agent"] = USERAGENT;
+  }
 
   let isDone = false;
 


### PR DESCRIPTION
Especially when trying to get metadata from sites like Twitter it can be useful to set a custom User-Agent, but currently this is always overriden by meta-extractor. With this change that only happens when the user hasn't defined a User-Agent at all.